### PR TITLE
build: Use fedora-toolbox image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest AS davincibox
+FROM registry.fedoraproject.org/fedora-toolbox:38 AS davincibox
 
 # Support Nvidia Container Runtime (https://developer.nvidia.com/nvidia-container-runtime)
 ENV NVIDIA_VISIBLE_DEVICES all


### PR DESCRIPTION
Currently, davincibox is building from the fedora:latest image, but this was only chosen because my other local fedora containers were using it, and not for any thoughtful reason. Switching to a fedora-toolbox image might fix #2 