### PR TITLE
feat: Manually create launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,22 @@ toolbox create -i ghcr.io/zelikos/davincibox:latest -c davincibox
 toolbox enter davincibox
 ```
 
-Then, run `setup-davinci /path/to/DaVinci_Resolve_version_Linux.run` from within the container, or
+Then, run `setup-davinci /path/to/DaVinci_Resolve_version_Linux.run distrobox/toolbox` from within the container
+
+e.g.
 
 Distrobox:
 
 ```
-distrobox enter davincibox -- setup-davinci /path/to/DaVinci_Resolve_version_Linux.run
+distrobox enter davincibox -- setup-davinci /path/to/DaVinci_Resolve_version_Linux.run distrobox
 ```
 
 Toolbox:
 
 ```
-toolbox run --container davincibox setup-davinci /path/to/DaVinci_Resolve_version_Linux.run
+toolbox run --container davincibox setup-davinci /path/to/DaVinci_Resolve_version_Linux.run toolbox
 ```
+
+The suffix at the end is for the `add-davinci-launcher` script. If omitted, setup will still run, but adding the launcher to your application menu won't work.
+
+You can still run `add-davinci-launcher` separately, as either `add-davinci-launcher distrobox` or `add-davinci-launcher toolbox`, depending on what you're using.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,21 @@ toolbox run --container davincibox setup-davinci /path/to/DaVinci_Resolve_versio
 The suffix at the end is for the `add-davinci-launcher` script. If omitted, setup will still run, but adding the launcher to your application menu won't work.
 
 You can still run `add-davinci-launcher` separately, as either `add-davinci-launcher distrobox` or `add-davinci-launcher toolbox`, depending on what you're using.
+
+## Uninstallation
+
+Distrobox:
+
+```
+distrobox enter davincibox -- add-davinci-launcher remove
+distrobox stop davincibox
+distrobox rm davincibox
+```
+
+Toolbox:
+
+```
+toolbox run --container davincibox add-davinci-launcher remove
+podman container stop davincibox
+toolbox rm davincibox
+```

--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ fi
 # Run setup-davinci
 if [[ $container_type == "distrobox" ]]
 then
-    distrobox enter davincibox -- setup-davinci $1
+    distrobox enter davincibox -- setup-davinci $1 $container_type
 else
-    toolbox run --container davincibox setup-davinci $1
+    toolbox run --container davincibox setup-davinci $1 $container_type
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-use_distrobox=false
+container_type=""
 
 # Check that argument containing DaVinci_Resolve_version_LInux.run was provided
 if [[ -f $(readlink -e $1) ]]
@@ -17,11 +17,11 @@ then
             echo "Please install either distrobox or toolbox to use this script."
             exit
         else
-            use_distrobox=false
+            container_type="toolbox"
             echo "Toolbox found."
         fi
     else
-        use_distrobox=true
+        container_type="distrobox"
         echo "Distrobox found."
     fi
 else
@@ -33,7 +33,7 @@ fi
 # Create davincibox on user's system
 echo "Setting up davincibox..."
 
-if $use_distrobox
+if [[ $container_type == "distrobox" ]]
 then
     distrobox create -i ghcr.io/zelikos/davincibox:latest -n davincibox
     # Start up the container now after creation,
@@ -45,7 +45,7 @@ else
 fi
 
 # Run setup-davinci
-if $use_distrobox
+if [[ $container_type == "distrobox" ]]
 then
     distrobox enter davincibox -- setup-davinci $1
 else

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -3,10 +3,26 @@
 container_type="distrobox"
 setup_launcher=true
 
-if [[ $1 == "--remove"  ]]
+if [[ $1 == "remove"  ]]
 then
     setup_launcher=false
-    echo "TODO"
+    echo "Removing DaVinci Resolve launcher..."
+
+    # Remoe graphics
+    rm -r ~/.local/share/resolve/graphics
+    rm ~/.local/share/icons/hicolor/256x256/mimetypes/application-x-braw-clip.png
+    rm ~/.local/share/icons/hicolor/48x48/mimetypes/application-x-braw-clip.png
+    rm ~/.local/share/icons/hicolor/256x256/mimetypes/application-x-braw-sidecar.png
+    rm ~/.local/share/icons/hicolor/48x48/mimetypes/application-x-braw-sidecar.png
+    rm ~/.local/share/icons/hicolor/256x256/apps/blackmagicraw-player.png
+    rm ~/.local/share/icons/hicolor/48x48/apps/blackmagicraw-player.png
+    rm ~/.local/share/icons/hicolor/256x256/apps/blackmagicraw-speedtest.png
+    rm ~/.local/share/icons/hicolor/48x48/apps/blackmagicraw-speedtest.png
+
+    # Remove launchers
+    rm ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+
+    echo "DaVinci Resolve launcher removed."
 else
     case $1 in
         "toolbox")      container_type="toolbox";
@@ -15,7 +31,7 @@ else
                         echo "Adding launcher for Toolbox...";;
         "distrobox")    echo "Adding launcher for Distrobox...";;
         *)              echo "${1} not recognized.";
-                        echo "Did you mean toolbox, distrobox, or --remove?"
+                        echo "Did you mean toolbox, distrobox, or remove?"
                         setup_launcher=false;;
     esac
 fi
@@ -43,7 +59,7 @@ then
     cp /opt/resolve/share/*.desktop ~/.local/share/applications
 
     # Remove DaVinci Resolve uninstaller, as we don't want to cause confusion.
-    # e.g. A user might think running the uninstaller also removes the container
+    # e.g. It may uninstall Resolve from the container, but the launchers would remain
     rm ~/.local/share/applications/DaVinciResolveInstaller.desktop
 
     sed -i 's/RESOLVE_INSTALL_LOCATION/\/opt\/resolve/' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
@@ -62,7 +78,7 @@ then
     echo "You can now launch DaVinci Resolve from your application menu."
     echo ""
     echo "If you want to remove the launchers later,"
-    echo "re-run this command with the --remove argument,"
+    echo "re-run this command with the remove argument,"
     echo "or delete the launchers directly from:"
     echo "$HOME/.local/share/applications"
 fi

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -4,13 +4,14 @@ if [[ $1 ]]
 then
     if [[ $1 == "--remove"  ]]
     then
-        # TODO
+        echo "TODO"
     else
         echo "Argument ${1} not recognized."
         echo "Did you mean --remove ?"
     fi
 else
     # Copy graphics
+    echo "Copying graphics..."
     mkdir -p ~/.local/share/resolve/graphics
     cp /opt/resolve/graphics/DV_* ~/.local/share/resolve/graphics
 
@@ -24,6 +25,7 @@ else
     cp /opt/resolve/graphics/blackmagicraw-speedtest_256x256_apps.png ~/.local/share/icons/hicolor/256x256/apps/blackmagicraw-speedtest.png
     cp /opt/resolve/graphics/blackmagicraw-speedtest_48x48_apps.png ~/.local/share/icons/hicolor/48x48/apps/blackmagicraw-speedtest.png
 
+    echo "Setting up launcher..."
     # Copy and adjust launchers
     mkdir -p ~/.local/share/applications
     cp /opt/resolve/share/*.desktop ~/.local/share/applications
@@ -31,4 +33,12 @@ else
     sed -i 's/Exec=/Exec=toolbox run --release 37 /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
     sed -i "s,Icon=/opt/resolve/graphics,Icon=$HOME/.local/share/resolve/graphics," ~/.local/share/applications/DaVinci*.desktop
     sed -i "s,Path=.*,Path=$HOME," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+
+    echo "Launcher setup complete."
+    echo "You can now launch DaVinci Resolve from your application menu."
+    echo ""
+    echo "If you want to remove the launchers later,"
+    echo "re-run this command with the --remove argument,"
+    echo "or delete the launchers directly from:"
+    echo "$HOME/.local/share/applications"
 fi

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -30,7 +30,7 @@ else
     mkdir -p ~/.local/share/applications
     cp /opt/resolve/share/*.desktop ~/.local/share/applications
     sed -i 's/RESOLVE_INSTALL_LOCATION/\/opt\/resolve/' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
-    sed -i 's/Exec=/Exec=toolbox run --release 37 /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+    sed -i 's/Exec=/Exec=\/usr\/bin\/distrobox enter davincibox -- /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
     sed -i "s,Icon=/opt/resolve/graphics,Icon=$HOME/.local/share/resolve/graphics," ~/.local/share/applications/DaVinci*.desktop
     sed -i "s,Path=.*,Path=$HOME," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
 

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -1,3 +1,34 @@
 #!/bin/bash
 
-echo "TODO"
+if [[ $1 ]]
+then
+    if [[ $1 == "--remove"  ]]
+    then
+        # TODO
+    else
+        echo "Argument ${1} not recognized."
+        echo "Did you mean --remove ?"
+    fi
+else
+    # Copy graphics
+    mkdir -p ~/.local/share/resolve/graphics
+    cp /opt/resolve/graphics/DV_* ~/.local/share/resolve/graphics
+
+    mkdir -p ~/.local/share/icons/hicolor/{48x48,256x256}/{apps,mimetypes}
+    cp /opt/resolve/graphics/application-x-braw-clip_256x256_mimetypes.png ~/.local/share/icons/hicolor/256x256/mimetypes/application-x-braw-clip.png
+    cp /opt/resolve/graphics/application-x-braw-clip_48x48_mimetypes.png ~/.local/share/icons/hicolor/48x48/mimetypes/application-x-braw-clip.png
+    cp /opt/resolve/graphics/application-x-braw-sidecar_256x256_mimetypes.png ~/.local/share/icons/hicolor/256x256/mimetypes/application-x-braw-sidecar.png
+    cp /opt/resolve/graphics/application-x-braw-sidecar_48x48_mimetypes.png ~/.local/share/icons/hicolor/48x48/mimetypes/application-x-braw-sidecar.png
+    cp /opt/resolve/graphics/blackmagicraw-player_256x256_apps.png ~/.local/share/icons/hicolor/256x256/apps/blackmagicraw-player.png
+    cp /opt/resolve/graphics/blackmagicraw-player_48x48_apps.png ~/.local/share/icons/hicolor/48x48/apps/blackmagicraw-player.png
+    cp /opt/resolve/graphics/blackmagicraw-speedtest_256x256_apps.png ~/.local/share/icons/hicolor/256x256/apps/blackmagicraw-speedtest.png
+    cp /opt/resolve/graphics/blackmagicraw-speedtest_48x48_apps.png ~/.local/share/icons/hicolor/48x48/apps/blackmagicraw-speedtest.png
+
+    # Copy and adjust launchers
+    mkdir -p ~/.local/share/applications
+    cp /opt/resolve/share/*.desktop ~/.local/share/applications
+    sed -i 's/RESOLVE_INSTALL_LOCATION/\/opt\/resolve/' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+    sed -i 's/Exec=/Exec=toolbox run --release 37 /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+    sed -i "s,Icon=/opt/resolve/graphics,Icon=$HOME/.local/share/resolve/graphics," ~/.local/share/applications/DaVinci*.desktop
+    sed -i "s,Path=.*,Path=$HOME," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+fi

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-if [[ $1 ]]
+container_type="distrobox"
+setup_launcher=true
+
+if [[ $1 == "--remove"  ]]
 then
-    if [[ $1 == "--remove"  ]]
-    then
-        echo "TODO"
-    else
-        echo "Argument ${1} not recognized."
-        echo "Did you mean --remove ?"
-    fi
+    setup_launcher=false
+    echo "TODO"
 else
+    case $1 in
+        "toolbox")      container_type="toolbox";
+                        echo "Adding launcher for Toolbox...";;
+        "toolbx")       container_type="toolbox";
+                        echo "Adding launcher for Toolbox...";;
+        "distrobox")    echo "Adding launcher for Distrobox...";;
+        *)              echo "${1} not recognized.";
+                        echo "Did you mean toolbox, distrobox, or --remove?"
+                        setup_launcher=false;;
+    esac
+fi
+
+if [[ $setup_launcher = true ]]
+then
     # Copy graphics
     echo "Copying graphics..."
     mkdir -p ~/.local/share/resolve/graphics
@@ -25,14 +37,21 @@ else
     cp /opt/resolve/graphics/blackmagicraw-speedtest_256x256_apps.png ~/.local/share/icons/hicolor/256x256/apps/blackmagicraw-speedtest.png
     cp /opt/resolve/graphics/blackmagicraw-speedtest_48x48_apps.png ~/.local/share/icons/hicolor/48x48/apps/blackmagicraw-speedtest.png
 
-    echo "Setting up launcher..."
     # Copy and adjust launchers
+    echo "Setting up launcher..."
     mkdir -p ~/.local/share/applications
     cp /opt/resolve/share/*.desktop ~/.local/share/applications
     sed -i 's/RESOLVE_INSTALL_LOCATION/\/opt\/resolve/' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
-    sed -i 's/Exec=/Exec=\/usr\/bin\/distrobox enter davincibox -- /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
     sed -i "s,Icon=/opt/resolve/graphics,Icon=$HOME/.local/share/resolve/graphics," ~/.local/share/applications/DaVinci*.desktop
     sed -i "s,Path=.*,Path=$HOME," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+
+    if [[ $container_type == "toolbox" ]]
+    then
+        sed -i 's/Exec=/Exec=\/usr\/bin\/toolbox run --container davincibox /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+    elif [[ $container_type == "distrobox" ]]
+    then
+        sed -i 's/Exec=/Exec=\/usr\/bin\/distrobox-enter -n davincibox -- /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+    fi
 
     echo "Launcher setup complete."
     echo "You can now launch DaVinci Resolve from your application menu."

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -38,9 +38,14 @@ then
     cp /opt/resolve/graphics/blackmagicraw-speedtest_48x48_apps.png ~/.local/share/icons/hicolor/48x48/apps/blackmagicraw-speedtest.png
 
     # Copy and adjust launchers
-    echo "Setting up launcher..."
+    echo "Setting up launchers..."
     mkdir -p ~/.local/share/applications
     cp /opt/resolve/share/*.desktop ~/.local/share/applications
+
+    # Remove DaVinci Resolve uninstaller, as we don't want to cause confusion.
+    # e.g. A user might think running the uninstaller also removes the container
+    rm ~/.local/share/applications/DaVinciResolveInstaller.desktop
+
     sed -i 's/RESOLVE_INSTALL_LOCATION/\/opt\/resolve/' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
     sed -i "s,Icon=/opt/resolve/graphics,Icon=$HOME/.local/share/resolve/graphics," ~/.local/share/applications/DaVinci*.desktop
     sed -i "s,Path=.*,Path=$HOME," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -50,7 +50,7 @@ then
         *)      add_launcher=false;;
     esac
 
-    if [[ $add_launcher = true]]
+    if [[ $add_launcher = true ]]
     then
         /usr/bin/add-davinci-launcher
     else

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -20,7 +20,7 @@ else
     exit
 fi
 
-if [[ $valid ]]
+if [[ $valid = true ]]
 then
     echo "Extracting ${installer} ..."
     $installer --appimage-extract
@@ -39,7 +39,7 @@ then
     fi
 fi
 
-if [[ $extract_success ]]
+if [[ $extract_success = true ]]
 then
     # TODO: Better phrasing
     echo "Add DaVinci Resolve launcher? y/N"
@@ -52,10 +52,13 @@ then
 
     if [[ $add_launcher = true ]]
     then
-        /usr/bin/add-davinci-launcher
+        /usr/bin/add-davinci-launcher $2
     else
         echo "To add a launcher for DaVinci Resolve later,"
         echo "run add-davinci-launcher from within the container."
+        echo "Note: You will have to specify if it is running for"
+        echo "distrobox or for toolbox."
+        echo "e.g. add-davinci-launcher distrobox"
         exit
     fi
 fi

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -50,7 +50,7 @@ then
         *)      add_launcher=false;;
     esac
 
-    if [[ $add_launcher ]]
+    if [[ $add_launcher = true]]
     then
         /usr/bin/add-davinci-launcher
     else

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -42,12 +42,12 @@ fi
 if [[ $extract_success = true ]]
 then
     # TODO: Better phrasing
-    echo "Add DaVinci Resolve launcher? y/N"
+    echo "Add DaVinci Resolve launcher? Y/n"
     read response
     case "$response" in
-        "y")    add_launcher=true;;
-        "Y")    add_launcher=true;;
-        *)      add_launcher=false;;
+        "n")    add_launcher=false;;
+        "N")    add_launcher=false;;
+        *)      add_launcher=true;;
     esac
 
     if [[ $add_launcher = true ]]


### PR DESCRIPTION
Fixes #3 
Fixes #4 

- Implemented `add-davinci-launcher` to handle setting up .desktop files and icons, as well as their removal
- `setup-davinci` can now take a second argument to tell `add-davinci-launcher` if distrobox or toolbox are being used
- `setup.sh` passes said argument to `setup-davinci`
- README updated with new info
- Other cleanups/fixes