### PR TITLE
docs: Clarify that this is for Resolve on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # davincibox
 
-This project aims to provide a ready-to-go container with all of the needed dependencies to install and run DaVinci Resolve, based on information compiled by bluesabre in his [GitHub Gist](https://gist.github.com/bluesabre/8814afece711b0ca49de34c41e50b296).
+This project aims to provide a ready-to-go container with all of the needed dependencies to install and run DaVinci Resolve on Linux, based on information compiled by bluesabre in his [GitHub Gist](https://gist.github.com/bluesabre/8814afece711b0ca49de34c41e50b296). This is primarily intended for users of image-based systems such as Fedora Silverblue, but can be used on any Linux distro that distrobox is available on.
 
 ## Disclaimer
 


### PR DESCRIPTION
It should already be obvious when distrobox and toolbox are mentioned, but it's probably for the best to clarify that this is meant for DaVinci Resolve on Linux specifically, not other platforms.