### PR TITLE
fix: Add pipewire-alsa to fix no audio on some systems

### DIFF
--- a/extra-packages
+++ b/extra-packages
@@ -19,6 +19,7 @@ libXtst
 libXxf86vm
 mesa-libGLU
 mtdev
+pipewire-alsa
 pulseaudio-libs
 rocm-opencl
 xcb-util


### PR DESCRIPTION
Fixes #28 