### PR TITLE
fix: updated gdk_pixbuf to prevent g_task_set_static_name error

### DIFF
--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -5,6 +5,10 @@ valid=false
 extract_success=false
 add_launcher=false
 
+gdk_pixbuf_tmp_dir=/tmp/gdk-pixbuf
+fc38_gdk_pixbuf_package=gdk-pixbuf2-2.42.10-2.fc38.x86_64.rpm
+fc38_gdk_pixbuf_url=https://dl.fedoraproject.org/pub/fedora/linux/releases/38/Everything/x86_64/os/Packages/g/$fc38_gdk_pixbuf_package
+
 if [[ $1 ]]
 then
     installer=$(readlink -e $1)
@@ -32,6 +36,13 @@ then
         # May not be needed in the future
         sudo rm /opt/resolve/libs/libglib-2.0.so /opt/resolve/libs/libglib-2.0.so.0 /opt/resolve/libs/libglib-2.0.so.0.6800.4
         rm -rf squashfs-root/
+        # Fix for: gdk_pixbuf undefined symbol: g_task_set_static_name
+        # Thanks to MiMillieuh https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/ju9ygqx
+        mkdir -p $gdk_pixbuf_tmp_dir
+        wget $fc38_gdk_pixbuf_url -P $gdk_pixbuf_tmp_dir
+        rpm2cpio $gdk_pixbuf_tmp_dir/$fc38_gdk_pixbuf_package | cpio -idmv -D $gdk_pixbuf_tmp_dir
+        sudo cp -r $gdk_pixbuf_tmp_dir/usr/lib64/* /opt/resolve/libs/
+        rm -rf $gdk_pixbuf_tmp_dir
     else
         echo "${installer} could not be extracted."
         echo "Please double-check that it is a valid DaVinci Resolve installer."


### PR DESCRIPTION
Applied [MiMillieuh's fix](https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/ju9ygqx/) for the error:

`/opt/resolve/bin/resolve: symbol lookup error: /usr/lib/libgdk_pixbuf-2.0.so.0: undefined symbol: g_task_set_static_name`