### PR TITLE
docs(README): Fix manual upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Run `setup.sh upgrade`, then follow the installation steps above.
 
 ### Manual
 
-See the Uninstallation section below, then go through manual setup again.
+First, run `podman image pull ghcr.io/zelikos/davincibox:latest`
+
+Then, follow the Uninstallation section below and go through manual setup again.
 
 ## Uninstallation
 


### PR DESCRIPTION
Actually updating the container image is part of `setup.sh` already, but I neglected to mention doing so in the manual upgrade instructions.