### PR TITLE
docs: Update README.md for nvidia and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ You will need [`distrobox`](https://github.com/89luca89/distrobox) or [`toolbox`
 
 You will need [Podman](https://podman.io/)
 
-If using an Nvidia GPU, you will also need the `nvidia-cuda-toolkit` package installed to your system.
-
-which can be installed with `sudo apt install nvidia-cuda-toolkit`
-
 You will also need the latest release of DaVinci Resolve from [Blackmagic's website](https://www.blackmagicdesign.com/products/davinciresolve)
 
 If you're less comfortable in the CLI, I recommend using the `setup.sh` script from this repository to help simplify the setup process, but ultimately use of the CLI is currently a requirement.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Davincibox has **not** been tested with DaVinci Resolve Studio. See [#26](https:
 
 ## Requirements
 
-You will need `distrobox` or `toolbox`. Distrobox is highly recommended for ease of use.
+You will need [`distrobox`](https://github.com/89luca89/distrobox) or [`toolbox`](https://github.com/containers/toolbox). Distrobox is highly recommended for ease of use.
 
-If using an Nvidia GPU, you will also need the `nvidia-container-runtime` package installed to your system.
+If using an Nvidia GPU, you will also need the `nvidia-cuda-toolkit` package installed to your system.
+
+which can be installed with `sudo apt install nvidia-cuda-toolkit`
 
 You will also need the latest release of DaVinci Resolve from [Blackmagic's website](https://www.blackmagicdesign.com/products/davinciresolve)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Davincibox has **not** been tested with DaVinci Resolve Studio. See [#26](https:
 
 You will need [`distrobox`](https://github.com/89luca89/distrobox) or [`toolbox`](https://github.com/containers/toolbox). Distrobox is highly recommended for ease of use.
 
+You will need [Podman](https://podman.io/)
+
 If using an Nvidia GPU, you will also need the `nvidia-cuda-toolkit` package installed to your system.
 
 which can be installed with `sudo apt install nvidia-cuda-toolkit`


### PR DESCRIPTION
fixed a few outdated things in the readme and convenience

the nvidia-container-runtime has been deprecated in favor of the NVIDIA container toolkit.

also added links to direct people to the github pages of Distrobox and Toolbox.