### PR TITLE
build(Containerfile): Use upstream fedora-toolbox image as base

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ublue-os/fedora-distrobox:latest AS davincibox
+FROM quay.io/fedora/fedora-toolbox:39 AS davincibox
 
 # Support Nvidia Container Runtime (https://developer.nvidia.com/nvidia-container-runtime)
 ENV NVIDIA_VISIBLE_DEVICES all


### PR DESCRIPTION
There *shouldn't* be any regressions from making this switch, as this image was originally built on the `fedora` container image before I switched it over to uBlue's `fedora-distrobox`. The reason for the original change was because the latter was optimized for distrobox, but in hindsight I'd like to keep the image smaller for those that prefer toolbox + I want to explore using podman directly in the future instead.

Closes #55 