### PR TITLE
docs(README): Use correct package name of `nvidia-container-toolkit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you're less comfortable in the CLI, I recommend using the `setup.sh` script f
 
 ### NVIDIA
 
-NVIDIA users will need to install the `nvidia-container-runtime`. If you are using a [Universal Blue](https://universal-blue.org/) image such as [Bluefin](https://projectbluefin.io/), this will already be installed. Otherwise, see [NVIDIA's installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) for instructions for your distribution.
+NVIDIA users will need to install the `nvidia-container-toolkit`. If you are using a [Universal Blue](https://universal-blue.org/) image such as [Bluefin](https://projectbluefin.io/), this will already be installed. Otherwise, see [NVIDIA's installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) for instructions for your distribution.
 
 ## Setup
 


### PR DESCRIPTION
`nvidia-container-runtime` is the old package name but I mixed them up when doing #56...even though I had it correct in the PR's title...