### PR TITLE
docs(README): Fix install instructions, update disclaimers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ e.g.
 Distrobox:
 
 ```
-distrobox enter davincibox -- setup-davinci /path/to/DaVinci_Resolve_version_Linux.run distrobox
+distrobox enter davincibox -- setup-davinci squashfs-root/AppRun distrobox
 ```
 
 Toolbox:
 
 ```
-toolbox run --container davincibox setup-davinci /path/to/DaVinci_Resolve_version_Linux.run toolbox
+toolbox run --container davincibox setup-davinci squashfs-root/AppRun toolbox
 ```
 
 The suffix at the end is for the `add-davinci-launcher` script. If omitted, setup will still run, but adding the launcher to your application menu won't work.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This project aims to provide a ready-to-go container with all of the needed depe
 
 ### GPU Support
 
-I've only been able to test this setup with an AMD RX 6600XT GPU. NVIDIA cards, Intel cards, and other generations of AMD cards are completely untested. See [#21](https://github.com/zelikos/davincibox/issues/21)
+I've only been able to test this setup with an AMD RX 6600XT GPU. Other users have contributed test results here: [#21](https://github.com/zelikos/davincibox/issues/21)
 
 ### DaVinci Resolve Studio
 
-Davincibox has **not** been tested with DaVinci Resolve Studio. See [#26](https://github.com/zelikos/davincibox/issues/26)
+Davincibox has had limited testing with DaVinci Resolve Studio. Use at your own risk. See [#26](https://github.com/zelikos/davincibox/issues/26)
 
 ## Requirements
 


### PR DESCRIPTION
Fixes the toolbox and distrobox commands for `setup-davinci` to use `squashfs-root` now (per #60)

Updates the disclaimers section to be a bit more accurate, now that we've had contributions for info on working GPUs and DaVinci Resolve Studio.