### PR TITLE
feat: Add rusticl as opt-in option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ You will also need the latest release of DaVinci Resolve from [Blackmagic's webs
 
 If you're less comfortable in the CLI, I recommend using the `setup.sh` script from this repository to help simplify the setup process, but ultimately use of the CLI is currently a requirement.
 
+### AMD
+
+Currently, davincibox uses ROCm by default for AMD GPUs. However, [GPU support in ROCm is very limited](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-gpus), and some users may have reported [issues](https://github.com/zelikos/davincibox/issues/65) when using it. Davincibox now also includes `mesa-libOpenCL`, and so `rusticl` can be tried as an alternative.
+
+If you experience issues using ROCm and would like to test rusticl:
+
+- Follow the davincibox setup instructions below as normal
+- Run DaVinci Resolve with:
+    - Toolbox: `toolbox run -c davincibox /usr/bin/run-davinci rusticl`
+    - Distrobox: `distrobox enter -n davincibox -- /usr/bin/run-davinci rusticl`
+
+If rusticl does work better for you and you would like to launch Resolve with rusticl automatically, you can also adjust the `DaVinciResolve.desktop` file in `$HOME/.local/share/applications`. Add `rusticl` to the end of the `Exec=` line, before `%u`. e.g. `Exec=/usr/bin/toolbox run -c davincibox /usr/bin/run-davinci rusticl %u`
+
 ### NVIDIA
 
 NVIDIA users will need to install the `nvidia-container-toolkit`. If you are using a [Universal Blue](https://universal-blue.org/) image such as [Bluefin](https://projectbluefin.io/), this will already be installed. Otherwise, see [NVIDIA's installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) for instructions for your distribution.

--- a/extra-packages
+++ b/extra-packages
@@ -18,6 +18,7 @@ libXrandr
 libXtst
 libXxf86vm
 mesa-libGLU
+mesa-libOpenCL
 mtdev
 pipewire-alsa
 pulseaudio-libs

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 container_type="distrobox"
+container_run_command=""
 setup_launcher=true
 
 if [[ $1 == "remove"  ]]
@@ -66,13 +67,13 @@ then
     sed -i "s,Icon=/opt/resolve/graphics,Icon=$HOME/.local/share/resolve/graphics," ~/.local/share/applications/DaVinci*.desktop
     sed -i "s,Path=.*,Path=$HOME," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
 
-    if [[ $container_type == "toolbox" ]]
-    then
-        sed -i 's/Exec=/Exec=env QT_QPA_PLATFORM=xcb \/usr\/bin\/toolbox run --container davincibox /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
-    elif [[ $container_type == "distrobox" ]]
-    then
-        sed -i 's/Exec=/Exec=env QT_QPA_PLATFORM=xcb \/usr\/bin\/distrobox-enter -n davincibox -- /' ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+    if [[ $container_type == "toolbox" ]]; then
+        container_run_command="/usr/bin/toolbox run -c davincibox"
+    elif [[ $container_type == "distrobox" ]]; then
+        container_run_command="/usr/bin/distrobox-enter -n davincibox --"
     fi
+
+    sed -i "s,Exec=/opt/resolve/bin/resolve,Exec=$container_run_command /usr/bin/run-davinci," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
 
     # Overwrite shortcut created by upstream DaVinci Resolve installer
     desktop_shortcut=$HOME/Desktop/com.blackmagicdesign.resolve.desktop

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-QT_QPA_PLATFORM=xcb RUSTICL_ENABLE=radeonsi,iris,nouveau OCL_ICD_VENDORS=rusticl.icd /opt/resolve/bin/resolve
+if [[ $1 == "rusticl" ]]; then
+  QT_QPA_PLATFORM=xcb RUSTICL_ENABLE=radeonsi,iris,nouveau OCL_ICD_VENDORS=rusticl.icd /opt/resolve/bin/resolve
+else
+  QT_QPA_PLATFORM=xcb /opt/resolve/bin/resolve
+fi

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+QT_QPA_PLATFORM=xcb RUSTICL_ENABLE=radeonsi,iris,nouveau OCL_ICD_VENDORS=rusticl.icd /opt/resolve/bin/resolve

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -27,7 +27,7 @@ fi
 if [[ $valid = true ]]
 then
     # See https://github.com/zelikos/davincibox/issues/35
-    sudo QT_QPA_PLATFORM=minimal $installer -i -a -y
+    sudo QT_QPA_PLATFORM=minimal SKIP_PACKAGE_CHECK=1 $installer -i -a -y
     if [[ $? -eq 0 ]]; then
         install_success=true
         # Workaround for an issue with Resolve's included libglib-2.0


### PR DESCRIPTION
- Adds SKIP_PACKAGE_CHECK=1 during DaVinci Resolve installation, due to an error with the installer not detecting that zlib is present
- Adds mesa-libOpenCL for rusticl
- Makes rusticl opt-in with `run-davinci`