### PR TITLE
fix: gdk pixbuf symbol lookup error

### DIFF
--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 export LD_PRELOAD=/usr/lib64/libglib-2.0.so.0:/usr/lib64/libgdk_pixbuf-2.0.so.0:/usr/lib64/libgio-2.0.so.0:/usr/lib64/libgmodule-2.0.so.0
+export QT_QPA_PLATFORM=xcb
 
 if [[ $1 == "rusticl" ]]; then
-  QT_QPA_PLATFORM=xcb RUSTICL_ENABLE=radeonsi,iris,nouveau OCL_ICD_VENDORS=rusticl.icd /opt/resolve/bin/resolve
-else
-  QT_QPA_PLATFORM=xcb /opt/resolve/bin/resolve
+  export RUSTICL_ENABLE=radeonsi,iris,nouveau
+  export OCL_ICD_VENDORS=rusticl.icd
 fi
+
+/opt/resolve/bin/resolve

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LD_PRELOAD=/usr/lib64/libglib-2.0.so.0:/usr/lib64/libgdk_pixbuf-2.0.so.0:/usr/lib64/libgio-2.0.so.0:/usr/lib64/libgmodule-2.0.so.0
+
 if [[ $1 == "rusticl" ]]; then
   QT_QPA_PLATFORM=xcb RUSTICL_ENABLE=radeonsi,iris,nouveau OCL_ICD_VENDORS=rusticl.icd /opt/resolve/bin/resolve
 else

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Info for this line comes from here: https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/l2cwo27/
+# Slightly modified, as the original wasn't pointed to the correct lib file names
 export LD_PRELOAD=/usr/lib64/libglib-2.0.so.0:/usr/lib64/libgdk_pixbuf-2.0.so.0:/usr/lib64/libgio-2.0.so.0:/usr/lib64/libgmodule-2.0.so.0
 export QT_QPA_PLATFORM=xcb
 

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -26,9 +26,6 @@ then
     sudo QT_QPA_PLATFORM=minimal SKIP_PACKAGE_CHECK=1 $installer -i -a -y
     if [[ $? -eq 0 ]]; then
         install_success=true
-        # Workaround for an issue with Resolve's included libglib-2.0
-        # May not be needed in the future
-        sudo rm /opt/resolve/libs/libglib-2.0.so /opt/resolve/libs/libglib-2.0.so.0 /opt/resolve/libs/libglib-2.0.so.0.6800.4
     fi
 fi
 

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -5,10 +5,6 @@ valid=false
 install_success=false
 add_launcher=false
 
-gdk_pixbuf_tmp_dir=/tmp/gdk-pixbuf
-fc38_gdk_pixbuf_package=gdk-pixbuf2-2.42.10-2.fc38.x86_64.rpm
-fc38_gdk_pixbuf_url=https://dl.fedoraproject.org/pub/fedora/linux/releases/38/Everything/x86_64/os/Packages/g/$fc38_gdk_pixbuf_package
-
 if [[ $1 ]]
 then
     installer=$(readlink -e $1)
@@ -33,13 +29,6 @@ then
         # Workaround for an issue with Resolve's included libglib-2.0
         # May not be needed in the future
         sudo rm /opt/resolve/libs/libglib-2.0.so /opt/resolve/libs/libglib-2.0.so.0 /opt/resolve/libs/libglib-2.0.so.0.6800.4
-        # Fix for: gdk_pixbuf undefined symbol: g_task_set_static_name
-        # Thanks to MiMillieuh https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/ju9ygqx
-        mkdir -p $gdk_pixbuf_tmp_dir
-        wget $fc38_gdk_pixbuf_url -P $gdk_pixbuf_tmp_dir
-        rpm2cpio $gdk_pixbuf_tmp_dir/$fc38_gdk_pixbuf_package | cpio -idmv -D $gdk_pixbuf_tmp_dir
-        sudo cp -r $gdk_pixbuf_tmp_dir/usr/lib64/* /opt/resolve/libs/
-        rm -rf $gdk_pixbuf_tmp_dir
     fi
 fi
 


### PR DESCRIPTION
- Removes the old gdk-pixbuf workaround since the required F38 package is no longer available
- Uses LD_PRELOAD to make Resolve use container's `libglib`, `libgdk_pixbuf`, `libgio`, and `libgmodule` without altering the DaVinci Resolve installation
- Refactors `run-davinci` to improve legibility

Closes #78 