### PR TITLE
fix(adl): Remove `/usr/bin/` prefix from distrobox shortcut

### DIFF
--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -70,7 +70,7 @@ then
     if [[ $container_type == "toolbox" ]]; then
         container_run_command="/usr/bin/toolbox run -c davincibox"
     elif [[ $container_type == "distrobox" ]]; then
-        container_run_command="/usr/bin/distrobox-enter -n davincibox --"
+        container_run_command="distrobox-enter -n davincibox --"
     fi
 
     sed -i "s,Exec=/opt/resolve/bin/resolve,Exec=$container_run_command /usr/bin/run-davinci," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop


### PR DESCRIPTION
- Omits the `/usr/bin/` prefix from distrobox desktop shortcuts to account for certain distrobox installation methods installing distrobox to a different path.
- Leaves toolbox path alone since that's more Fedora-specific and *should* always be at `/usr/bin/toolbox`

Fixes #80 