### PR TITLE
fix: Ensure Fedora packages are updated during setup

### DIFF
--- a/.github/workflows/build-davincibox.yml
+++ b/.github/workflows/build-davincibox.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 0 * * TUE'
+    - cron: '0 0 * * *'
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ First, run `podman image pull ghcr.io/zelikos/davincibox:latest`
 
 Then, follow the Uninstallation section below and go through manual setup again.
 
+After setup, run `sudo dnf update` in the container to ensure drivers are up to date:
+
+```
+# Distrobox
+distrobox enter davincibox -- sudo dnf update
+
+# Toolbox
+toolbox run -c davincibox sudo dnf update
+```
+
 ## Uninstallation
 
 Run `./setup.sh remove`, or

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ You can still run `add-davinci-launcher` separately, as either `add-davinci-laun
 
 After installation completes, you can remove the `squashfs-root` directory.
 
+After setup, run `sudo dnf update` in the container to ensure drivers are up to date:
+
+```
+# Distrobox
+distrobox enter davincibox -- sudo dnf update
+
+# Toolbox
+toolbox run -c davincibox sudo dnf update
+```
+
 ## Upgrading
 
 Upgrading requires re-creating the davincibox container with the newest version of the image.
@@ -145,16 +155,6 @@ Run `setup.sh upgrade`, then follow the installation steps above.
 First, run `podman image pull ghcr.io/zelikos/davincibox:latest`
 
 Then, follow the Uninstallation section below and go through manual setup again.
-
-After setup, run `sudo dnf update` in the container to ensure drivers are up to date:
-
-```
-# Distrobox
-distrobox enter davincibox -- sudo dnf update
-
-# Toolbox
-toolbox run -c davincibox sudo dnf update
-```
 
 ## Uninstallation
 

--- a/setup.sh
+++ b/setup.sh
@@ -55,11 +55,13 @@ else
 
     if [[ $container_type == "distrobox" ]]; then
         distrobox create -i ghcr.io/zelikos/davincibox:latest -n davincibox
-        # Start up the container now after creation,
-        # rather than during the later steps
+        # Ensure packages are up-to-date in case of old container build
+        distrobox enter davincibox -- sudo dnf -y update
         distrobox enter davincibox -- echo "davincibox initialized"
     else
         toolbox create -i ghcr.io/zelikos/davincibox:latest -c davincibox
+        # Ensure packages are up-to-date in case of old container build
+        toolbox run --container davincibox sudo dnf -y update
         toolbox run --container davincibox echo "davincibox initialized"
     fi
 


### PR DESCRIPTION
- Makes builds daily instead of weekly
- Add a note about running `sudo dnf update` when upgrading davincibox
- Adds `sudo dnf update` steps into `setup.sh`

Closes #84 
Closes #85 