### PR TITLE
feat(run-davinci): Default to rusticl for AMD GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you need to run davincibox from the CLI instead of using a desktop shortcut, 
   - Distrobox: `distrobox enter -n davincibox -- /usr/bin/run-davinci`
   - Toolbox: `toolbox run -c davincibox /usr/bin/run-davinci`
 
+## Requirements & GPU Information
 
 You will need [Podman](https://podman.io/), as well as [`distrobox`](https://github.com/89luca89/distrobox) or [`toolbox`](https://github.com/containers/toolbox).
 
@@ -31,23 +32,21 @@ If you're less comfortable in the CLI, I recommend using the `setup.sh` script f
 
 ### AMD
 
-Currently, davincibox uses ROCm by default for AMD GPUs. However, [GPU support in ROCm is very limited](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-gpus), and ROCm frequently [has](https://github.com/ROCm/ROCm/issues/768) [issues](https://github.com/zelikos/davincibox/issues/65) with DaVinci Resolve. Davincibox now also includes `mesa-libOpenCL`, and so `rusticl` can be tried as an alternative.
+AMD uses Mesa's `rusticl` for OpenCL support in DaVinci Resolve, due [various](https://github.com/ROCm/ROCm/issues/768) [issues](https://github.com/zelikos/davincibox/issues/65) with AMD's official option, ROCm. These issues largely stem from the fact that [GPU support in ROCm is very limited](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-gpus).
 
-If you experience issues using ROCm and would like to [test rusticl](https://github.com/zelikos/davincibox/issues/72):
+ROCm does remain available as a fallback option:
+  - Distrobox: `distrobox enter -n davincibox -- /usr/bin/run-davinci rocm`
+  - Toolbox: `toolbox run -c davincibox /usr/bin/run-davinci rocm`
 
-- **Make sure davincibox is [up-to-date](https://github.com/zelikos/davincibox?tab=readme-ov-file#upgrading)**
-- Follow the davincibox setup instructions below as normal
-- Run DaVinci Resolve with:
-    - Toolbox: `toolbox run -c davincibox /usr/bin/run-davinci rusticl`
-    - Distrobox: `distrobox enter -n davincibox -- /usr/bin/run-davinci rusticl`
-
-If rusticl does work better for you and you would like to launch Resolve with rusticl automatically, you can also adjust the `DaVinciResolve.desktop` file in `$HOME/.local/share/applications`. Add `rusticl` to the end of the `Exec=` line, before `%u`. e.g. `Exec=/usr/bin/toolbox run -c davincibox /usr/bin/run-davinci rusticl %u`
+If ROCm does work better for you and you would like to launch Resolve with ROCm automatically, you can also adjust the `DaVinciResolve.desktop` file in `$HOME/.local/share/applications`. Add `rocm` to the end of the `Exec=` line, before `%u`. e.g. `Exec=/usr/bin/toolbox run -c davincibox /usr/bin/run-davinci rocm %u`
 
 ### Intel
 
 For Intel GPUs, the `intel-compute-runtime` package is included and used by default.
 
-Like with AMD, `rusticl` is available to test as an alternative for Intel users. See the relevant instructions above.
+`rusticl` is available to test as an alternative for Intel users. Similar to running ROCm for AMD as shown above, you can use `run-davinci rusticl` in the container to use `rusticl` instead of the `intel-compute-runtime`:
+  - Distrobox: `distrobox enter -n davincibox -- /usr/bin/run-davinci rusticl`
+  - Toolbox: `toolbox run -c davincibox /usr/bin/run-davinci rusticl`
 
 ### NVIDIA
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ Davincibox has had limited testing with DaVinci Resolve Studio. Use at your own 
 
 DaVinci Resolve on Linux, especially the free version, has limited codec support. Unless you can show that certain codecs are available when using DaVinci Resolve outside of davincibox, but not within davincibox, **do not** report issues about missing codecs here.
 
-## Requirements
+### Running from the CLI
+
+If you need to run davincibox from the CLI instead of using a desktop shortcut, you'll need to use the `run-davinci` script in davincibox, as it contains necessary workarounds for DaVinci Resolve to work in the container's Fedora Linux environment.
+  - Distrobox: `distrobox enter -n davincibox -- /usr/bin/run-davinci`
+  - Toolbox: `toolbox run -c davincibox /usr/bin/run-davinci`
+
 
 You will need [Podman](https://podman.io/), as well as [`distrobox`](https://github.com/89luca89/distrobox) or [`toolbox`](https://github.com/containers/toolbox).
 

--- a/extra-packages
+++ b/extra-packages
@@ -3,6 +3,7 @@ alsa-lib
 apr
 apr-util
 dbus-libs
+glx-utils
 intel-compute-runtime
 libglvnd-egl
 libglvnd-glx

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -5,9 +5,30 @@
 export LD_PRELOAD=/usr/lib64/libglib-2.0.so.0:/usr/lib64/libgdk_pixbuf-2.0.so.0:/usr/lib64/libgio-2.0.so.0:/usr/lib64/libgmodule-2.0.so.0
 export QT_QPA_PLATFORM=xcb
 
-if [[ $1 == "rusticl" ]]; then
+gpu_type=""
+
+get_gpu_type () {
+  if [[ -n $(glxinfo -B | grep -i AMD) ]]; then
+    gpu_type="amd"
+  elif [[ -n $(glxinfo -B | grep -i Intel) ]]; then
+    gpu_type="intel"
+  elif [[ -n $(glxinfo -B | grep -i nvidia) ]]; then
+    gpu_type="nvidia"
+  fi
+}
+
+use_rusticl () {
   export RUSTICL_ENABLE=radeonsi,iris,nouveau
   export OCL_ICD_VENDORS=rusticl.icd
+}
+
+get_gpu_type
+
+# Default to rusticl on AMD GPUs
+# Don't use rusticl if arg rocm is passed
+# Allow use of arg rusticl to opt in for Intel and Nvidia nouveau users
+if [[ $gpu_type == "amd" && $1 != "rocm" || $1 == "rusticl" ]]; then
+  use_rusticl
 fi
 
 /opt/resolve/bin/resolve


### PR DESCRIPTION
- Adds `glx-utils` to allow GPU detection with `glxinfo`
- Switches to rusticl by default for AMD, but keeps ROCm as a fallback via `rocm` arg
- Keeps `rusticl` arg for Intel and Nvidia nouveau users to test
- Adds note about using `run-davinci` script when running davincibox + DaVinci Resolve in the CLI

Closes #87 
Related to #72 