### PR TITLE
fix(run-davinci): Check for Nvidia GPU first

### DIFF
--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -8,12 +8,12 @@ export QT_QPA_PLATFORM=xcb
 gpu_type=""
 
 get_gpu_type () {
-  if [[ -n $(glxinfo -B | grep -i AMD) ]]; then
+  if [[ -n $(glxinfo -B | grep -i nvidia) ]]; then
+    gpu_type="nvidia"
+  elif [[ -n $(glxinfo -B | grep -i AMD) ]]; then
     gpu_type="amd"
   elif [[ -n $(glxinfo -B | grep -i Intel) ]]; then
     gpu_type="intel"
-  elif [[ -n $(glxinfo -B | grep -i nvidia) ]]; then
-    gpu_type="nvidia"
   fi
 }
 


### PR DESCRIPTION
Right now, this shouldn't actually have a big effect on things, since we're not applying any Nvidia-specific workarounds in `run-davinci` at the moment, but in the future, if we need to for e.g. laptops with Intel iGPUs + Nvidia dGPUs, we'll want to check for the Nvidia GPU first.