### PR TITLE
fix(setup.sh): More reliable nvidia detection

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -23,8 +23,8 @@ set_container_type () {
 }
 
 get_gpu_type () {
-    if command -v glxinfo &> /dev/null; then
-        if [[ -n $(glxinfo -B | grep -i nvidia) ]]; then
+    if command -v lshw &> /dev/null; then
+        if lshw -c video 2>/dev/null | grep -qi nvidia; then
             echo "Nvidia GPU detected."
             nvidia_gpu=true
         fi


### PR DESCRIPTION
glxinfo only detects nvidia cards in hybrid GPUs laptops when executed prefixed of switcherooctl (which basically sets the env vars), or using `lshw -c video` (which lists all video devices, regardless of env vars)