### PR TITLE
fix(adl): Manually source davinci.sh for distrobox

### DIFF
--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -70,10 +70,16 @@ then
     if [[ $container_type == "toolbox" ]]; then
         container_run_command="/usr/bin/toolbox run -c davincibox"
     elif [[ $container_type == "distrobox" ]]; then
-        container_run_command="distrobox-enter -n davincibox --"
+        # distrobox-enter ignores /etc/profile.d, so we have to source it manually
+        container_run_command="distrobox-enter -n davincibox -- bash -c 'source /etc/profile.d/davinci.sh \&\&"
     fi
 
     sed -i "s,Exec=,Exec=$container_run_command ," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+
+    if [[ $container_type == "distrobox" ]]; then
+        # Add a ' to enclose the distrobox-enter command set above
+        sed -i "/Exec*/s/$/'/" ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+    fi
 
     # Overwrite shortcut created by upstream DaVinci Resolve installer
     desktop_shortcut=$HOME/Desktop/com.blackmagicdesign.resolve.desktop

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -71,13 +71,14 @@ then
         container_run_command="/usr/bin/toolbox run -c davincibox"
     elif [[ $container_type == "distrobox" ]]; then
         # distrobox-enter ignores /etc/profile.d, so we have to source it manually
+        # The matching ' for the bash -c below is added in a subsequent sed to account for the different binaries
         container_run_command="distrobox-enter -n davincibox -- bash -c 'source /etc/profile.d/davinci.sh \&\&"
     fi
 
     sed -i "s,Exec=,Exec=$container_run_command ," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
 
     if [[ $container_type == "distrobox" ]]; then
-        # Add a ' to enclose the distrobox-enter command set above
+        # Add a ' to enclose the bash -c string in the distrobox-enter command set above
         sed -i "/Exec*/s/$/'/" ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
     fi
 


### PR DESCRIPTION
Unlike Toolbx, distrobox-enter ignores `/etc/profile.d` files, so we have to manually source `davinci.sh` before running DaVinci Resolve and the other included programs

Closes #106 