### PR TITLE
refactor(adl): Use `bash -cl` to ensure a login shell for distrobox

### DIFF
--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -70,17 +70,11 @@ then
     if [[ $container_type == "toolbox" ]]; then
         container_run_command="/usr/bin/toolbox run -c davincibox"
     elif [[ $container_type == "distrobox" ]]; then
-        # distrobox-enter ignores /etc/profile.d, so we have to source it manually
-        # The matching ' for the bash -c below is added in a subsequent sed to account for the different binaries
-        container_run_command="distrobox-enter -n davincibox -- bash -c 'source /etc/profile.d/davinci.sh \&\&"
+        # distrobox-enter ignores /etc/profile.d, so we have to ensure it uses a login shell
+        container_run_command="distrobox-enter -n davincibox -- bash -cl"
     fi
 
     sed -i "s,Exec=,Exec=$container_run_command ," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
-
-    if [[ $container_type == "distrobox" ]]; then
-        # Add a ' to enclose the bash -c string in the distrobox-enter command set above
-        sed -i "/Exec*/s/$/'/" ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
-    fi
 
     # Overwrite shortcut created by upstream DaVinci Resolve installer
     desktop_shortcut=$HOME/Desktop/com.blackmagicdesign.resolve.desktop


### PR DESCRIPTION
See https://github.com/zelikos/davincibox/pull/107#issuecomment-2253689350

This is cleaner than the previous solution of manually sourcing `davinci.sh` before running the respective program