### PR TITLE
refactor: Utilize patchelf instead of LD_PRELOAD

### DIFF
--- a/extra-packages
+++ b/extra-packages
@@ -32,3 +32,4 @@ xcb-util-keysyms
 xcb-util-renderutil
 xcb-util-wm
 xorg-x11-drv-nvidia-cuda
+patchelf

--- a/system_files/etc/profile.d/davinci.sh
+++ b/system_files/etc/profile.d/davinci.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Info for this line comes from here: https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/l2cwo27/
-# Slightly modified, as the original wasn't pointed to the correct lib file names
-export LD_PRELOAD=/usr/lib64/libglib-2.0.so.0:/usr/lib64/libgdk_pixbuf-2.0.so.0:/usr/lib64/libgio-2.0.so.0:/usr/lib64/libgmodule-2.0.so.0
 export QT_QPA_PLATFORM=xcb
 
 gpu_type=""

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -71,7 +71,7 @@ then
         container_run_command="/usr/bin/toolbox run -c davincibox"
     elif [[ $container_type == "distrobox" ]]; then
         # distrobox-enter ignores /etc/profile.d, so we have to ensure it uses a login shell
-        container_run_command="distrobox-enter -n davincibox -- "
+        container_run_command="distrobox-enter -n davincibox -- bash -cl"
     fi
 
     sed -i "s,Exec=,Exec=$container_run_command ," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -71,7 +71,7 @@ then
         container_run_command="/usr/bin/toolbox run -c davincibox"
     elif [[ $container_type == "distrobox" ]]; then
         # distrobox-enter ignores /etc/profile.d, so we have to ensure it uses a login shell
-        container_run_command="distrobox-enter -n davincibox -- bash -cl"
+        container_run_command="distrobox-enter -n davincibox -- "
     fi
 
     sed -i "s,Exec=,Exec=$container_run_command ," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -33,6 +33,7 @@ if [[ $install_success = true ]]
 then
     # Patch davinci binaries to remove need for LD_PRELOAD workaround mentioned in
     # https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/l2cwo27/
+    echo "Patching resolve binaries..."
     libs=(
         /usr/lib64/libglib-2.0.so.0
         /usr/lib64/libgdk_pixbuf-2.0.so.0

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -31,6 +31,24 @@ fi
 
 if [[ $install_success = true ]]
 then
+    # Patch davinci binaries to remove need for LD_PRELOAD workaround mentioned in
+    # https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/l2cwo27/
+    libs=(
+        /usr/lib64/libglib-2.0.so.0
+        /usr/lib64/libgdk_pixbuf-2.0.so.0
+        /usr/lib64/libgio-2.0.so.0
+        /usr/lib64/libgmodule-2.0.so.0
+    )
+    patchelf_args=""
+    for lib in "${libs[@]}"; do
+        patchelf_args="${patchelf_args} --add-needed ${lib} "
+    done
+    unset lib -v
+
+    # shellcheck disable=SC2086
+    find /opt/resolve/bin -executable -type f -exec sudo patchelf $patchelf_args {} \;
+    unset libs -v
+
     # TODO: Better phrasing
     echo "Add DaVinci Resolve launcher? Y/n"
     read response


### PR DESCRIPTION
This will remove the need of using LD_PRELOAD as of https://www.reddit.com/r/voidlinux/comments/12g71x0/comment/l2cwo27/ by forcing DaVinci Resolve binaries to use the listed libraries at the specified absolute paths:
- /usr/lib64/libglib-2.0.so.0
- /usr/lib64/libgdk_pixbuf-2.0.so.0
- /usr/lib64/libgio-2.0.so.0
- /usr/lib64/libgmodule-2.0.so.0