### PR TITLE
fix: Check for GPU driver name, not just vendor

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ set_container_type () {
 
 get_gpu_type () {
     if command -v lshw &> /dev/null; then
-        if lshw -c video 2>/dev/null | grep -qi nvidia; then
+        if lshw -c video 2>/dev/null | grep -qi "driver=nvidia"; then
             echo "Nvidia GPU detected."
             nvidia_gpu=true
         fi

--- a/system_files/etc/profile.d/davinci.sh
+++ b/system_files/etc/profile.d/davinci.sh
@@ -5,10 +5,11 @@ export QT_QPA_PLATFORM=xcb
 gpu_type=""
 
 get_gpu_type () {
-  if lshw -c video 2>/dev/null | grep -qi nvidia; then
+  if lshw -c video 2>/dev/null | grep -qi "driver=nvidia"; then
     gpu_type="nvidia"
-  elif lshw -c video 2>/dev/null | grep -qi amd; then
+  elif lshw -c video 2>/dev/null | grep -qi "driver=amdgpu"; then
     gpu_type="amd"
+  # TODO: Check for Intel driver name(s) instead
   elif lshw -c video 2>/dev/null | grep -qi intel; then
     gpu_type="intel"
   fi

--- a/system_files/etc/profile.d/davinci.sh
+++ b/system_files/etc/profile.d/davinci.sh
@@ -5,17 +5,17 @@ export QT_QPA_PLATFORM=xcb
 gpu_type=""
 
 get_gpu_type () {
-  # Checks only for nvidia driver and not nouveau, as nouveau is handled differently than the proprietary driver
+  # Checks only for nvidia driver and not nouveau
   if lshw -c video 2>/dev/null | grep -qi "driver=nvidia"; then
     gpu_type="nvidia"
-  # Checks for amdgpu and not radeon, as any GPUs that outright require the radeon driver
-  # are *very* unlikely to handle running DaVinci Resolve anyway
+  # Checks for amdgpu so that we can specify using rusticl by default
   elif lshw -c video 2>/dev/null | grep -qi "driver=amdgpu"; then
     gpu_type="amd"
-  elif lshw -c video 2>/dev/null | grep -qi "driver=i915"; then
-    gpu_type="intel"
-  elif lshw -c video 2>/dev/null | grep -qi "driver=xe"; then
-    gpu_type="intel"
+  # We don't have any special handling necessary for Intel GPUs at this time,
+  # so we aren't currently checking for them.
+  # In case we need to in the future, the Intel drivers are:
+  # - driver=i915
+  # - driver=xe
   fi
 }
 

--- a/system_files/etc/profile.d/davinci.sh
+++ b/system_files/etc/profile.d/davinci.sh
@@ -12,8 +12,9 @@ get_gpu_type () {
   # are *very* unlikely to handle running DaVinci Resolve anyway
   elif lshw -c video 2>/dev/null | grep -qi "driver=amdgpu"; then
     gpu_type="amd"
-  # TODO: Check for Intel driver name(s) instead
-  elif lshw -c video 2>/dev/null | grep -qi intel; then
+  elif lshw -c video 2>/dev/null | grep -qi "driver=i915"; then
+    gpu_type="intel"
+  elif lshw -c video 2>/dev/null | grep -qi "driver=xe"; then
     gpu_type="intel"
   fi
 }

--- a/system_files/etc/profile.d/davinci.sh
+++ b/system_files/etc/profile.d/davinci.sh
@@ -5,8 +5,11 @@ export QT_QPA_PLATFORM=xcb
 gpu_type=""
 
 get_gpu_type () {
+  # Checks only for nvidia driver and not nouveau, as nouveau is handled differently than the proprietary driver
   if lshw -c video 2>/dev/null | grep -qi "driver=nvidia"; then
     gpu_type="nvidia"
+  # Checks for amdgpu and not radeon, as any GPUs that outright require the radeon driver
+  # are *very* unlikely to handle running DaVinci Resolve anyway
   elif lshw -c video 2>/dev/null | grep -qi "driver=amdgpu"; then
     gpu_type="amd"
   # TODO: Check for Intel driver name(s) instead


### PR DESCRIPTION
Changes GPU checks in `setup.sh` and `davinci.sh` to check for the driver name in use, rather than GPU vendor.

Fixes #113 