### PR TITLE
docs(README): Clarify Upgrading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,11 @@ toolbox run -c davincibox sudo dnf update
 
 ## Upgrading
 
-Upgrading requires re-creating the davincibox container with the newest version of the image.
+Usually, you'll only need to update the packages in the container (i.e. driver updates), not the container image itself. In this case, simply run `sudo dnf update` in the container as shown above.
 
-If a new version of davincibox is available and you want to upgrade, you can do so manually or with `setup.sh`.
+Otherwise, a full upgrade requires re-creating the davincibox container with the newest version of the image. This should only needed if there have been changes to the `setup-davinci` or `add-davinci-launcher` scripts in the container. **When reporting issues, a full upgrade should be performed first**.
+
+If a new version of davincibox is available and you need to upgrade, you can do so manually or with `setup.sh`.
 
 ### `setup.sh`
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ toolbox run -c davincibox sudo dnf update
 
 ## Upgrading
 
-Usually, you'll only need to update the packages in the container (i.e. driver updates), not the container image itself. In this case, simply run `sudo dnf update` in the container as shown above.
+Usually, you'll only need to update the packages in the container (i.e. driver updates), not the container image itself. In this case, simply run `sudo dnf update` in davincibox as shown above.
 
-Otherwise, a full upgrade requires re-creating the davincibox container with the newest version of the image. This should only needed if there have been changes to the `setup-davinci` or `add-davinci-launcher` scripts in the container. **When reporting issues, a full upgrade should be performed first**.
+Otherwise, a full upgrade requires re-creating the davincibox container with the newest version of the image. This should only needed if there have been changes to the `setup-davinci` or `add-davinci-launcher` scripts used by davincibox. **When reporting issues, a full upgrade should be performed first**.
 
 If a new version of davincibox is available and you need to upgrade, you can do so manually or with `setup.sh`.
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ toolbox run -c davincibox sudo dnf update
 
 Usually, you'll only need to update the packages in the container (i.e. driver updates), not the container image itself. In this case, simply run `sudo dnf update` in davincibox as shown above.
 
-Otherwise, a full upgrade requires re-creating the davincibox container with the newest version of the image. This should only needed if there have been changes to the `setup-davinci` or `add-davinci-launcher` scripts used by davincibox. **When reporting issues, a full upgrade should be performed first**.
+Otherwise, a full upgrade requires re-creating the davincibox container with the newest version of the image. This should only needed if there has been a new GitHub release for davincibox, as this may include changes to the `setup-davinci` or `add-davinci-launcher` scripts. **When reporting issues, a full upgrade should be performed first**.
 
 If a new version of davincibox is available and you need to upgrade, you can do so manually or with `setup.sh`.
 


### PR DESCRIPTION
Adds to the Upgrading section that upgrades of the container *image* are only needed when davincibox's scripts are updated or prior to reporting an issue, and that `sudo dnf update` is sufficient otherwise.