### PR TITLE
fix: Add xcb-util-cursor

### DIFF
--- a/extra-packages
+++ b/extra-packages
@@ -27,6 +27,7 @@ pipewire-alsa
 pulseaudio-libs
 rocm-opencl
 xcb-util
+xcb-util-cursor
 xcb-util-image
 xcb-util-keysyms
 xcb-util-renderutil


### PR DESCRIPTION
Adds `xcb-util-cursor` to the davinci dependencies

Should fix #122 