### PR TITLE
docs(README): Add troubleshooting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,21 @@ podman container stop davincibox
 toolbox rm davincibox
 ```
 
+## Troubleshooting
+### No Audio output
+DaVinci Resolve uses ALSA. In `davincibox` this is supported via the `pipewire-alsa` plugin, which re-directs sound to pipewire.
+This however requires that the host system provides a pipewire server. If your host-system uses some other sound server, this might not work.
+
+You can either convert your host system to provide `pipewire` or change your `davincibox` instance to use any sound server you have running.
+
+For example, if your host-system uses `pulse-audio`, you can change `davincibox` as follows:
+
+```
+> distrobox-enter -n davincibox -- bash
+> sudo dnf remove pipewire-alsa
+> sudo dnf install alsa-plugins-pulseaudio
+```
+
 ## Credits
 
 Sean Davis, AKA [bluesabre](https://github.com/bluesabre)

--- a/README.md
+++ b/README.md
@@ -221,10 +221,10 @@ This however requires that the host system provides a pipewire server. If your h
 
 You can either convert your host system to provide `pipewire` or change your `davincibox` instance to use any sound server you have running.
 
-For example, if your host-system uses `pulse-audio`, you can change `davincibox` as follows:
+For example, if your host-system uses `pulseaudio`, you can change `davincibox` as follows:
 
 ```
-> distrobox-enter -n davincibox -- bash
+> distrobox-enter -n davincibox
 > sudo dnf remove pipewire-alsa
 > sudo dnf install alsa-plugins-pulseaudio
 ```


### PR DESCRIPTION
Thanks for this project! I think it is awesome!! With this I finally got Resolve running on my Arch-Linux installation after many years :-)

I ran into some audio issues related to my Arch installation using Pulseaudio.
I added a section to the `README.md` which might help others.

Feel free to merge or propose changes.
In an ideal world the installer could detect or ask for the installed sound system and then create the `distrobox` image accordingly. But I did not have time to look into it this far. So I thought adding the info to the `README.md` is better than nothing.