### PR TITLE
fix(setup.sh): Use absolute paths for internal scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,7 @@ run_davinci_setup () {
     if [[ $? -eq 0 ]]; then
       # Run setup-davinci
       extracted_installer="squashfs-root/AppRun"
-      $container_run_prefix setup-davinci $extracted_installer $container_type
+      $container_run_prefix /usr/bin/setup-davinci $extracted_installer $container_type
       rm -rf squashfs-root/
     else
         echo "${installer} could not be extracted."
@@ -112,7 +112,7 @@ else
 fi
 
 if [[ $1 == "remove" ]]; then
-    $container_run_prefix add-davinci-launcher remove
+    $container_run_prefix /usr/bin/add-davinci-launcher remove
 
     echo "Removing DaVinci Resolve and davincibox..."
     remove_davincibox_container


### PR DESCRIPTION
*Might* help with #140 since the error log provided mentioned a $PATH issue, but I couldn't reproduce the issue on my system so I can't verify. Even so, it's better to use the absolute path here just in case, and doesn't hurt to do so.