### PR TITLE
fix(nvidia): Rename libDecoderOpenCL.so for companion programs

### DIFF
--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -50,6 +50,19 @@ then
     find /opt/resolve/bin -executable -type f -exec sudo patchelf $patchelf_args {} \;
     unset libs -v
 
+    echo "Applying workaround for companion programs..."
+
+    decoders=(
+      /opt/resolve/BlackmagicRAWPlayer/BlackmagicRawAPI/libDecoderOpenCL.so
+      /opt/resolve/BlackmagicRAWSpeedTest/BlackmagicRawAPI/libDecoderOpenCL.so
+    )
+
+    for decoder in "${decoders[@]}"; do
+      sudo mv $decoder "${decoder}.bak"
+    done
+    unset decoder -v
+    unset decoders -v
+
     # TODO: Better phrasing
     echo "Add DaVinci Resolve launcher? Y/n"
     read response


### PR DESCRIPTION
Applies the workaround described in #137. This didn't have any noticeable negative effect on my AMD system using rusticl.