### PR TITLE
fix(opencl): Remove OpenCL-ICD-Loader before installing OpenCL packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,4 +18,5 @@ RUN rm /davinci-dependencies
 
 FROM davincibox AS davincibox-opencl
 
+RUN dnf -y remove OpenCL-ICD-Loader
 RUN dnf -y install intel-compute-runtime rocm-opencl


### PR DESCRIPTION
`mesa-libOpenCL` installs `OpenCL-ICD-Loader` as one of its dependencies, but the latter package conflicts with `ocl-icd`, which is a dependency of `rocm-opencl`. This removes `OpenCL-ICD-Loader` from the `davincibox-opencl` image.