### PR TITLE
fix: Support fractional scaling settings

### DIFF
--- a/system_files/etc/profile.d/davinci.sh
+++ b/system_files/etc/profile.d/davinci.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export QT_QPA_PLATFORM=xcb
+export QT_AUTO_SCREEN_SCALE_FACTOR=1
 
 gpu_type=""
 


### PR DESCRIPTION
Sets QT_AUTO_SCREEN_SCALE_FACTOR=1 (per #159) so that Resolve will follow fractional scaling settings set by the desktop environment. Tested on GNOME, not tested on other desktops.

Fixes #150 
Fixes #152