### PR TITLE
fix: Use updated flags for nvidia-container-toolkit distroboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ First, get davincibox set up. There are two different builds of davincibox, depe
 Distrobox:
 
 ```
-distrobox create -i ghcr.io/zelikos/davincibox:latest --nvidia -n davincibox
+distrobox create -i ghcr.io/zelikos/davincibox:latest --additional-flags "--gpus all" -n davincibox
 ```
 
 Toolbox:

--- a/setup.sh
+++ b/setup.sh
@@ -107,7 +107,7 @@ else
     set_container_type "distrobox"
     get_gpu_type
     if [[ $nvidia_gpu == true ]]; then
-        container_create_prefix+=" --nvidia"
+        container_create_prefix+=' --additional-flags "--gpus all"'
     fi
 fi
 


### PR DESCRIPTION
Per the [distrobox docs](https://github.com/89luca89/distrobox/blob/main/docs/useful_tips.md#using-nvidia-container-toolkit), `--additional-flags "--gpus all"` is now what's intended to be used for nvidia integration in the container, not `--nvidia`. This changes the manual setup instructions in the README accordingly, and updates `setup.sh` to use the new flag.