### PR TITLE
fix(opencl): Explicitly install `ocl-icd`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,11 +18,9 @@ RUN rm /davinci-dependencies
 
 FROM davincibox AS davincibox-opencl
 
-# rocm-opencl specifically depends on ocl-icd, which conflicts with OpenCL-ICD-Loader,
-# which was pulled in by mesa-libOpenCL in the davinci-dependencies above
-RUN dnf -y remove OpenCL-ICD-Loader
+# Ensure ocl-icd is installed, as OpenCL-ICD-Loader tends to be pulled in
+# as a dependency but does not work. See:
+# https://github.com/zelikos/davincibox/issues/158
+# https://github.com/zelikos/davincibox/issues/169
+RUN dnf -y install --allowerasing ocl-icd
 RUN dnf -y install intel-compute-runtime rocm-opencl
-# Re-add mesa-libOpenCL here because removing OpenCL-ICD-Loader removes it,
-# but re-installing mesa-libOpenCL doesn't pull OpenCL-ICD-Loader back in,
-# so rusticl and ROCm can still co-exist
-RUN dnf -y install mesa-libOpenCL


### PR DESCRIPTION
Because `OpenCL-ICD-Loader` doesn't work on AMD GPUs. Both work fine on Intel. Untested on NVIDIA, but most people are gonna use CUDA with NVIDIA anyway

Related to #158 
Fixes #169 