### PR TITLE
fix: Add ocl-icd to davinci-dependencies

### DIFF
--- a/davinci-dependencies
+++ b/davinci-dependencies
@@ -21,6 +21,7 @@ lshw
 mesa-libGLU
 mesa-libOpenCL
 mtdev
+ocl-icd
 pipewire-alsa
 pulseaudio-libs
 python3-gobject


### PR DESCRIPTION
This fixes an oversight from #174. rusticl was made to be opt-in, but mesa-libOpenCL pulls in OpenCL-ICD-Loader instead of ocl-icd, and rusticl only works with the latter. So, we'll make sure ocl-icd is explicitly installed.

Closes #186