### PR TITLE
fix: Add needed env for switcherooctl to work in distrobox

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,7 @@ Enter davincibox with:
   - Distrobox: `distrobox enter davincibox`
   - Toolbox: `toolbox enter davincibox`
 
-Then, to list the GPUs switcheroo-control detects:
-
-`switcherooctl list`
+Then, to list the GPUs switcheroo-control detects, run `list-gpus`; this is a wrapper for `switcherooctl list` that includes a needed environment variable for it to work in distrobox.
 
 The output should look something like this:
 

--- a/system_files/usr/bin/list-gpus
+++ b/system_files/usr/bin/list-gpus
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/host/var/run/dbus/system_bus_socket switcherooctl list

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -54,4 +54,4 @@ else
   DAVINCI_BIN="/opt/resolve/bin/resolve"
 fi
 
-switcherooctl launch $DAVINCI_BIN
+DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/host/var/run/dbus/system_bus_socket switcherooctl launch $DAVINCI_BIN


### PR DESCRIPTION
Adds an environment variable that is needed for switcherooctl to work in distrobox (not needed for Toolbox, but doesn't harm use in Toolbox either), as well as a `list-gpus` wrapper script for `switcherooctl list` including said environment variable.

Fixes #40 (again, for real this time hopefully)