### PR TITLE
fix: binaries with spaces, added StartupWMClass, added dependencies

### DIFF
--- a/davinci-dependencies
+++ b/davinci-dependencies
@@ -21,11 +21,13 @@ lshw
 mesa-libGLU
 mesa-libOpenCL
 mtdev
+nss
 ocl-icd
 pipewire-alsa
 pulseaudio-libs
 python3-gobject
 switcheroo-control
+xkbfile
 xcb-util
 xcb-util-cursor
 xcb-util-image

--- a/davinci-dependencies
+++ b/davinci-dependencies
@@ -14,6 +14,7 @@ libXfixes
 libXi
 libXinerama
 libxkbcommon-x11
+libxkbfile
 libXrandr
 libXtst
 libXxf86vm
@@ -27,7 +28,6 @@ pipewire-alsa
 pulseaudio-libs
 python3-gobject
 switcheroo-control
-xkbfile
 xcb-util
 xcb-util-cursor
 xcb-util-image

--- a/system_files/usr/bin/add-davinci-launcher
+++ b/system_files/usr/bin/add-davinci-launcher
@@ -4,6 +4,18 @@ container_type="distrobox"
 container_run_command=""
 setup_launcher=true
 
+# Function to check if a file exists and then append a line
+append_if_exists() {
+  local file_path="$1"
+  local content="$2"
+  if [ -f "$file_path" ]; then
+    echo "$content" >> "$file_path"
+    echo "Added '$content' to '$file_path'"
+  else
+    echo "Warning: File '$file_path' not found. Skipping append."
+  fi
+}
+
 if [[ $1 == "remove"  ]]
 then
     setup_launcher=false
@@ -36,6 +48,8 @@ else
                         setup_launcher=false;;
     esac
 fi
+
+
 
 if [[ $setup_launcher = true ]]
 then
@@ -74,6 +88,13 @@ then
     fi
 
     sed -i "s,Exec=,Exec=$container_run_command /usr/bin/run-davinci ," ~/.local/share/applications/{blackmagicraw*,DaVinci*}.desktop
+        
+    # Add StartupWMClass Property (Makes GNOME know which app each window belongs to)
+    append_if_exists "$HOME/.local/share/applications/blackmagicraw-player.desktop" "StartupWMClass=Blackmagic RAW Player"
+    append_if_exists "$HOME/.local/share/applications/blackmagicraw-speedtest.desktop" "StartupWMClass=Blackmagic RAW Speed Test"
+    append_if_exists "$HOME/.local/share/applications/DaVinciControlPanelsSetup.desktop" "StartupWMClass=DaVinci Control Panels Setup"
+    append_if_exists "$HOME/.local/share/applications/DaVinciRemoteMonitoring.desktop" "StartupWMClass=DaVinci Remote Monitor"
+    append_if_exists "$HOME/.local/share/applications/DaVinciResolve.desktop" "StartupWMClass=resolve"
 
     # Overwrite shortcut created by upstream DaVinci Resolve installer
     desktop_shortcut=$HOME/Desktop/com.blackmagicdesign.resolve.desktop

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -41,9 +41,9 @@ fi
 
 shift $((OPTIND - 1))
 
-if [[ $1 ]]; then
-  DAVINCI_BIN=$(readlink -e $1)
-  if [[ -f $DAVINCI_BIN ]]; then
+if [[ -n "$1" ]]; then  # Use -n for explicit non-empty string check
+  DAVINCI_BIN=$(readlink -e "$1") # Quote $1 here
+  if [[ -f "$DAVINCI_BIN" ]]; then
     echo "Launching $DAVINCI_BIN"
   else
     echo "$1 could not be found."
@@ -54,4 +54,4 @@ else
   DAVINCI_BIN="/opt/resolve/bin/resolve"
 fi
 
-DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/host/var/run/dbus/system_bus_socket switcherooctl launch $DAVINCI_BIN
+DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/host/var/run/dbus/system_bus_socket switcherooctl launch "$DAVINCI_BIN"


### PR DESCRIPTION
Hello, very helpful project. I thought I'd fix some issues I had.

A fixed quite a few issues:
1. Binaries with spaces such as /opt/resolve/DaVinci Control Panels Setup/DaVinci Control Panels Setup would not launch.
2. Added StartupWMClass for all the .desktop files to allow GNOME to properly recognize them as apps instead of unknown apps.
3. Added some missing dependencies for Davinci Control Panels Setup

Here is a before and after for the StartupWMClass changes:
**Before:**
![Screenshot From 2025-07-08 16-41-53 (Edit)](https://github.com/user-attachments/assets/33ac555e-f453-4bcb-98f1-3709a51e1fae)
**After:**
![Screenshot From 2025-07-08 16-38-26 (Edit)](https://github.com/user-attachments/assets/cd1a9867-99a7-4986-ade9-47c9bf56598c)

The DaVinci Resolve Capture Logs app also has missing dependencies but I was unable to figure out how to fix those.