### PR TITLE
fix: Update udev rule for USB licence keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,9 @@ An example udev rule is as follows:
 ```
 # Place this file in /etc/udev/rules.d/
 # Recommended file name: 90-davinci-usb.rules
+# Provides access to USB-based Davinci Resolve licence keys to unprivileged users.
 
-SUBSYSTEM=="usb", ATTR{idVendor}=="096e", TAG+="uaccess"
-
-# Allow access to toolbox / distrobox
-
-SUBSYSTEM=="usb", ATTR{idVendor}=="096e", MODE="0664", GROUP="users"
+SUBSYSTEM=="usb", ATTR{idVendor}=="096e", MODE="0664", GROUP="users", TAG+="uaccess"
 ```
 
 ### Dual GPU Systems


### PR DESCRIPTION
The existing rule no longer works on my test distro (Fedora Silverblue 43) due to having 2 different rules being applied, one of which does not work on this distro.

Instead, combine the 2 rules into 1 rule which should work across all relevant distros.