### PR TITLE
fix: Link host OFX plugins into davincibox

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ You can still run `add-davinci-launcher` separately, as either `add-davinci-laun
 
 After installation completes, you can remove the `squashfs-root` directory.
 
+If you install OpenFX plugins on the host in `/usr/OFX/Plugins`, `setup-davinci`
+will link that directory into the container so Resolve can see the same plugins.
+
 After setup, run `sudo dnf update` in the container to ensure drivers are up to date:
 
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ You can still run `add-davinci-launcher` separately, as either `add-davinci-laun
 
 After installation completes, you can remove the `squashfs-root` directory.
 
-If you install OpenFX plugins on the host in `/usr/OFX/Plugins`, `setup-davinci`
-will link that directory into the container so Resolve can see the same plugins.
+If you install OpenFX plugins on the host in `/usr/OFX/Plugins`, `run-davinci` will link that directory into the container when Resolve is launched so the same plugins are visible inside davincibox.
 
 After setup, run `sudo dnf update` in the container to ensure drivers are up to date:
 

--- a/system_files/usr/bin/run-davinci
+++ b/system_files/usr/bin/run-davinci
@@ -7,6 +7,44 @@ GPU_TYPE=""
 USE_RUSTICL=false
 DAVINCI_BIN=""
 
+# Additional host paths to symlink into the container.
+# Each entry is "host_path:container_path".
+HOST_LINKS=(
+  "/run/host/usr/OFX/Plugins:/usr/OFX/Plugins"
+)
+
+link_host_paths () {
+  for entry in "${HOST_LINKS[@]}"; do
+    local host_path="${entry%%:*}"
+    local container_path="${entry#*:}"
+
+    if [[ ! -d $host_path ]]; then
+      echo "Host path not found, skipping: $host_path"
+      continue
+    fi
+
+    # Already linked
+    if [[ -L $container_path ]]; then
+      echo "Already linked: $container_path -> $host_path"
+      continue
+    fi
+
+    # Container path has existing content - don't overwrite
+    if [[ -d $container_path ]] && find "$container_path" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+      echo "Skipping $container_path (already contains files)"
+      continue
+    fi
+
+    sudo mkdir -p "$(dirname "$container_path")"
+    sudo rm -rf "$container_path"
+    if sudo ln -s "$host_path" "$container_path"; then
+      echo "Linked: $container_path -> $host_path"
+    else
+      echo "Failed to link: $container_path -> $host_path"
+    fi
+  done
+}
+
 get_gpu_type () {
   # Checks only for nvidia driver and not nouveau
   if lshw -c video 2>/dev/null | grep -qi "driver=nvidia"; then
@@ -53,5 +91,7 @@ else
   echo "No path specified. Launching /opt/resolve/bin/resolve"
   DAVINCI_BIN="/opt/resolve/bin/resolve"
 fi
+
+link_host_paths
 
 DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/host/var/run/dbus/system_bus_socket switcherooctl launch "$DAVINCI_BIN"

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -5,32 +5,6 @@ valid=false
 install_success=false
 add_launcher=false
 
-link_host_ofx_plugins () {
-    local host_ofx_dir="/run/host/usr/OFX/Plugins"
-    local container_ofx_root="/usr/OFX"
-    local container_ofx_dir="${container_ofx_root}/Plugins"
-
-    if [[ ! -d $host_ofx_dir ]]; then
-        return
-    fi
-
-    echo "Linking host OFX plugins..."
-    sudo mkdir -p "$container_ofx_root"
-
-    if [[ -L $container_ofx_dir ]]; then
-        return
-    fi
-
-    if [[ -d $container_ofx_dir ]] && find "$container_ofx_dir" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
-        echo "${container_ofx_dir} already contains plugins."
-        echo "Skipping automatic OFX symlink to avoid overwriting container files."
-        return
-    fi
-
-    sudo rm -rf "$container_ofx_dir"
-    sudo ln -s "$host_ofx_dir" "$container_ofx_dir"
-}
-
 if [[ $1 ]]
 then
     installer=$(readlink -e $1)
@@ -88,8 +62,6 @@ then
     done
     unset decoder -v
     unset decoders -v
-
-        link_host_ofx_plugins
 
     # TODO: Better phrasing
     echo "Add DaVinci Resolve launcher? Y/n"

--- a/system_files/usr/bin/setup-davinci
+++ b/system_files/usr/bin/setup-davinci
@@ -5,6 +5,32 @@ valid=false
 install_success=false
 add_launcher=false
 
+link_host_ofx_plugins () {
+    local host_ofx_dir="/run/host/usr/OFX/Plugins"
+    local container_ofx_root="/usr/OFX"
+    local container_ofx_dir="${container_ofx_root}/Plugins"
+
+    if [[ ! -d $host_ofx_dir ]]; then
+        return
+    fi
+
+    echo "Linking host OFX plugins..."
+    sudo mkdir -p "$container_ofx_root"
+
+    if [[ -L $container_ofx_dir ]]; then
+        return
+    fi
+
+    if [[ -d $container_ofx_dir ]] && find "$container_ofx_dir" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+        echo "${container_ofx_dir} already contains plugins."
+        echo "Skipping automatic OFX symlink to avoid overwriting container files."
+        return
+    fi
+
+    sudo rm -rf "$container_ofx_dir"
+    sudo ln -s "$host_ofx_dir" "$container_ofx_dir"
+}
+
 if [[ $1 ]]
 then
     installer=$(readlink -e $1)
@@ -62,6 +88,8 @@ then
     done
     unset decoder -v
     unset decoders -v
+
+        link_host_ofx_plugins
 
     # TODO: Better phrasing
     echo "Add DaVinci Resolve launcher? Y/n"


### PR DESCRIPTION
### Problem
Resolve inside the container cannot see host-installed OFX plugins such as [Gyroflow](https://docs.gyroflow.xyz/app/video-editor-plugins/davinci-resolve-openfx#installation).  

This change makes `/run/host/usr/OFX/Plugins` available at Plugins so those plugins are discovered automatically.