### PR TITLE
feat: Rebase davincibox onto Fedora 44

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-toolbox:42 AS davincibox
+FROM quay.io/fedora/fedora-toolbox:44 AS davincibox
 
 # Support Nvidia Container Runtime (https://developer.nvidia.com/nvidia-container-runtime)
 ENV NVIDIA_VISIBLE_DEVICES all


### PR DESCRIPTION
Long overdue to upgrade from Fedora 42.

For any users that need to use an older build, follow manual installation instructions and replace `latest` with an appropriate date tag, in `YYYYMMDD` format. E.g. `davincibox:20260512`