### PR TITLE
docs(README): Simplify troubleshooting commands for changing audio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,8 @@ You can either convert your host system to provide `pipewire` or change your `da
 For example, if your host-system uses `pulseaudio`, you can change `davincibox` as follows:
 
 ```
-> distrobox-enter -n davincibox
-> sudo dnf remove pipewire-alsa
-> sudo dnf install alsa-plugins-pulseaudio
+distrobox enter davincibox -- sudo dnf remove pipewire-alsa
+distrobox enter davincibox -- sudo dnf install alsa-plugins-pulseaudio
 ```
 
 ### Resolve Studio crashes on "Checking Licences..."


### PR DESCRIPTION
I wanted to try this troubleshooting step and was a bit annoyed I can't just copy-paste and run this form the readme.
I've tested this on my bazzite system and saw a different audio device in my system tray afterwards.