### PR TITLE
docs(README): Add "Resolve fails to export media" section to troubleshooting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ For example, if your host-system uses `pulseaudio`, you can change `davincibox` 
 > sudo dnf install alsa-plugins-pulseaudio
 ```
 
+### Resolve fails to export media (e.g. "Failed to write the video frame")
+DaVinci's internal codecs seem to have some issues at times with some types of source media in combination with some output formats.
+To fix this you can either:
+- Swap to using another output format (Usually uncompressed formats work okay)
+- Install the FFMpeg encoder plugin, found here: https://github.com/EdvinNilsson/ffmpeg_encoder_plugin , and export using an FFMpeg encoder.
+
+Note that `davincibox` does not currently ship one of the dependancies required by the FFMpeg encoder plugin, but this can be fixed by entering the container and running:  `sudo dnf install libva`
+
 ### Resolve Studio crashes on "Checking Licences..."
 If you're a user of DaVinci Resolve Studio and have a USB Licence key, some Linux distributions may require you to add a udev rule to enable access to communicate with the USB key from within the container.
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ For example, if your host-system uses `pulseaudio`, you can change `davincibox` 
 DaVinci's internal codecs seem to have some issues at times with some types of source media in combination with some output formats.
 To fix this you can either:
 - Swap to using another output format (Usually uncompressed formats work okay)
-- Install the FFMpeg encoder plugin, found here: https://github.com/EdvinNilsson/ffmpeg_encoder_plugin , and export using an FFMpeg encoder.
+- (Resolve Studio ONLY) Install the FFMpeg encoder plugin, found here: https://github.com/EdvinNilsson/ffmpeg_encoder_plugin , and export using an FFMpeg encoder.
 
 Note that `davincibox` does not currently ship one of the dependancies required by the FFMpeg encoder plugin, but this can be fixed by entering the container and running:  `sudo dnf install libva`
 


### PR DESCRIPTION
Adds the "Resolve fails to export media" section to the troubleshooting doc.

I had to deal with this recently and spent possibly too much time doing so. Let's save others from the same fate.